### PR TITLE
add dbdev app manifest for scoop

### DIFF
--- a/dbdev.json
+++ b/dbdev.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.1.2",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/supabase/dbdev/releases/download/v0.1.2/dbdev-v0.1.2-windows-amd64.zip",
+            "bin": [
+                "dbdev.exe"
+            ],
+            "hash": "8686153083b0ca5894703c5a549bbddb13f8063d39a48ec4f87717c1f1073ab6"
+        }
+    },
+    "homepage": "https://database.dev",
+    "license": "Apache",
+    "description": "CLI to help publish extensions to database.dev"
+}


### PR DESCRIPTION
This PR adds a `dbdev` app manifest so that it can be installed with `scoop install supabase_scoop-bucket/dbdev`. 