### PR TITLE
Release dbdev version v0.1.7

### DIFF
--- a/dbdev.json
+++ b/dbdev.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.1.6",
+    "version": "0.1.7",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/supabase/dbdev/releases/download/v0.1.6/dbdev-v0.1.6-windows-amd64.zip",
+            "url": "https://github.com/supabase/dbdev/releases/download/v0.1.7/dbdev-v0.1.7-windows-amd64.zip",
             "bin": [
                 "dbdev.exe"
             ],
-            "hash": "0d60f5301f7bb944c14739edf7083d463e9decfba522c0b648008ea2302fb623"
+            "hash": "36a8bba791ed0eec2f97a4e21ccdc425e83af4040609b7d311553cfbf7190fb0"
         }
     },
     "homepage": "https://database.dev",


### PR DESCRIPTION
This PR updates the Scoop manifest for dbdev to version v0.1.7.

It was auto-generated by the dbdev release workflow.
