### PR TITLE
fix: correct v2.107.0 windows hashes

### DIFF
--- a/supabase.json
+++ b/supabase.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/supabase/cli/releases/download/v2.107.0/supabase_windows_amd64.tar.gz",
-            "hash": "d034226a3290de9abbf9ae8c6341a21dbc7277b292d3e612645f5016f3f18df2"
+            "hash": "644eaf7e67cf1b50eea76826c7a4e135e6b8f829d6f24a04e0c3be2bf1f13471"
         },
         "arm64": {
             "url": "https://github.com/supabase/cli/releases/download/v2.107.0/supabase_windows_arm64.tar.gz",
-            "hash": "9c41523bde45253cc60a5443210cbd1074f70d3525b3b0fa82f17c821a0cab29"
+            "hash": "66a15bac6f775ec89d195a4f66125309c69b4781eb308569c8f0414c06a9b4ef"
         }
     },
     "bin": "supabase.exe",


### PR DESCRIPTION
## What changed

Replaces both `hash` values in `supabase.json` for v2.107.0 with the checksums from the release `checksums.txt`.

| arch | hash |
|---|---|
| 64bit | `644eaf7e67cf1b50eea76826c7a4e135e6b8f829d6f24a04e0c3be2bf1f13471` |
| arm64 | `66a15bac6f775ec89d195a4f66125309c69b4781eb308569c8f0414c06a9b4ef` |

## Why

`scoop install supabase` failed for 2.107.0 because the manifest carried hashes that match no released artifact. The downloads are legit — the metadata was wrong. The publish step computed checksums from the `build-blacksmith` build, but the GitHub Release ships the `build-github` build, and Bun binaries are not byte-for-byte reproducible across runners.

The manifest points at the unversioned `supabase_windows_{amd64,arm64}.tar.gz` URLs; these are byte-identical to the versioned tarballs, so the versioned `checksums.txt` entries apply. Both corrected values were verified by downloading and hashing the exact unversioned artifacts. URLs are unchanged.

The pipeline root-cause fix (preventing this on future releases) is tracked separately in `supabase/cli`; this PR is the one-file remediation for the live 2.107.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RN3jAPQqsRnuzgYugDSazd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RN3jAPQqsRnuzgYugDSazd)_